### PR TITLE
Settings: Add build user to about phone

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -3141,6 +3141,10 @@
     <string name="kernel_version">Kernel version</string>
     <!-- About phone screen,  setting option name  [CHAR LIMIT=40] -->
     <string name="build_number">Build number</string>
+    <!-- About phone screen,  setting option name  [CHAR LIMIT=40] -->
+    <string name="build_user">Build user</string>
+    <!-- About phone screen,  setting option name  [CHAR LIMIT=40] -->
+    <string name="build_username">unknown</string>
     <!-- About phone screen, tapping this button will take user to a seperate UI to check Google Play system update [CHAR LIMIT=60] -->
     <string name="module_version">Google Play system update</string>
 

--- a/res/xml/my_device_info.xml
+++ b/res/xml/my_device_info.xml
@@ -181,27 +181,35 @@
         android:title="@string/fcc_equipment_id"
         android:summary="@string/summary_placeholder"/>
 
+    <!-- Build user -->
+    <Preference
+        android:key="build_user"
+        android:order="53"
+        android:title="@string/build_user"
+        android:summary="@string/build_username"
+        settings:allowDividerAbove="true"
+        settings:enableCopying="true"/>
+
     <!-- Build number -->
     <Preference
         android:key="build_number"
-        android:order="53"
+        android:order="54"
         android:title="@string/build_number"
         android:summary="@string/summary_placeholder"
-        settings:allowDividerAbove="true"
         settings:enableCopying="true"
         settings:controller="com.android.settings.deviceinfo.BuildNumberPreferenceController"/>
 
     <!-- omni version -->
     <Preference
         android:key="omni_version"
-        android:order="54"
+        android:order="55"
         android:title="@string/mod_version"
         android:summary="@string/mod_version_default"/>
 
     <!-- SELinux status information -->
     <Preference
         android:key="selinux_status"
-        android:order="55"
+        android:order="56"
         android:title="@string/selinux_status"
         android:summary="@string/selinux_status_enforcing"/>
 

--- a/src/com/android/settings/deviceinfo/BuildUserPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/BuildUserPreferenceController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.R;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+
+public class BuildUserPreferenceController extends AbstractPreferenceController implements
+        PreferenceControllerMixin {
+
+    private static final String KEY_BUILD_USER = "build_user";
+    
+    private static final String PROPERTY_BUILD_USER = "ro.build.user";
+    
+    private static final String PROPERTY_BUILD_HOST = "ro.build.host";
+
+    private static final String PROPERTY_CUST_BUILD_USER = "ro.omni.builder";
+
+    public BuildUserPreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        
+        super.updateState(preference);
+        
+        String cust_build_user = SystemProperties.get(PROPERTY_CUST_BUILD_USER);
+        String build_user = SystemProperties.get(PROPERTY_BUILD_USER);
+        String build_host = SystemProperties.get(PROPERTY_BUILD_HOST);
+        String build_user_host = build_user + "@" + build_host;
+        
+        if (cust_build_user != null && cust_build_user.length() > 0) {
+
+            preference.setSummary(cust_build_user);
+
+        } else {
+
+            preference.setSummary(build_user_host);
+        }
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_BUILD_USER;
+    }
+}

--- a/src/com/android/settings/deviceinfo/aboutphone/MyDeviceInfoFragment.java
+++ b/src/com/android/settings/deviceinfo/aboutphone/MyDeviceInfoFragment.java
@@ -31,6 +31,7 @@ import com.android.settings.Utils;
 import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.deviceinfo.BluetoothAddressPreferenceController;
 import com.android.settings.deviceinfo.BuildNumberPreferenceController;
+import com.android.settings.deviceinfo.BuildUserPreferenceController;
 import com.android.settings.deviceinfo.DeviceNamePreferenceController;
 import com.android.settings.deviceinfo.FccEquipmentIdPreferenceController;
 import com.android.settings.deviceinfo.FeedbackPreferenceController;
@@ -118,7 +119,9 @@ public class MyDeviceInfoFragment extends DashboardFragment
         controllers.add(new FccEquipmentIdPreferenceController(context));
         controllers.add(new UptimePreferenceController(context, lifecycle));
         controllers.add(new SELinuxStatusPreferenceController(context));
+        controllers.add(new BuildUserPreferenceController(context));
         controllers.add(new OmniVersionPreferenceController(context));
+
         return controllers;
     }
 


### PR DESCRIPTION
Programmatically gets build user and build host from build.prop. Also allows for specification of custom values using property override `ro.omni.builder`. This could easily be adapted to other ROMs as well. Based directly off the SELinuxStatusPreferenceController so we know it was written correctly. 

Change-Id: I031040dc0b87d547a8cee73cef219d11d938c32d